### PR TITLE
Allow star imports

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -54,10 +54,6 @@
         </module>
         <!-- https://source.android.com/source/code-style.html#dont-use-finalizers -->
         <module name="NoFinalizer"/>
-        <!-- https://source.android.com/source/code-style.html#fully-qualify-imports -->
-        <module name="AvoidStarImport">
-            <property name="excludes" value="java.io,java.util,junit.framework"/>
-        </module>
         <!-- https://source.android.com/source/code-style.html#use-spaces-for-indentation -->
         <module name="Indentation">
             <property name="basicOffset" value="4"/>


### PR DESCRIPTION
Java import statements are [syntactic sugar](https://stackoverflow.com/a/12621026); they exist purely to make the code below them more readable, by allowing you to use names that are not fully qualified.

Good IDEs report unused imports, so the need to "[Make] it obvious what classes are actually used and the code is more readable for maintainers" ([source](https://source.android.com/setup/contribute/code-style#fully-qualify-imports)) seems like solving a problem that isn't one.

As well, this star import was added automatically by my IDE. In this case, I prefer to let automation do its work, rather than to fight against it. 