### PR TITLE
Copyright Header Check

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -16,10 +16,16 @@
 
     <property name="fileExtensions" value="java, properties, xml"/>
 
-    <!-- Check for copyright header. -->
+    <!-- Check for copyright header in C comment style. -->
     <module name="Header">
-        <property name="headerFile" value="config/checkstyle/header.txt"/>
+        <property name="headerFile" value="config/checkstyle/header.c.txt"/>
         <property name="fileExtensions" value="java, proto"/>
+    </module>
+
+    <!-- Check for copyright header in XML/HTML comment style. -->
+    <module name="Header">
+        <property name="headerFile" value="config/checkstyle/header.xml.txt"/>
+        <property name="fileExtensions" value="xml"/>
     </module>
 
     <!-- https://source.android.com/source/code-style.html#use-spaces-for-indentation -->

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -16,6 +16,12 @@
 
     <property name="fileExtensions" value="java, properties, xml"/>
 
+    <!-- Check for copyright header. -->
+    <module name="Header">
+        <property name="headerFile" value="config/checkstyle/header.txt"/>
+        <property name="fileExtensions" value="java, xml, proto"/>
+    </module>
+
     <!-- https://source.android.com/source/code-style.html#use-spaces-for-indentation -->
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -19,7 +19,7 @@
     <!-- Check for copyright header. -->
     <module name="Header">
         <property name="headerFile" value="config/checkstyle/header.txt"/>
-        <property name="fileExtensions" value="java, xml, proto"/>
+        <property name="fileExtensions" value="java, proto"/>
     </module>
 
     <!-- https://source.android.com/source/code-style.html#use-spaces-for-indentation -->


### PR DESCRIPTION
This PR adds a check that verifies the contents of `config/checkstyle/header.txt` is present as a header of all Java, XML, and Protobuf files.

(In most cases, `header.txt` will contain the Left Technologies copyright statement.)